### PR TITLE
Connect PFDCM client to backend

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,6 @@ BROWSER=chrome
 REACT_APP_CHRIS_UI_URL="http://localhost:8000/api/v1/"
 REACT_APP_CHRIS_UI_USERS_URL="${REACT_APP_CHRIS_UI_URL}users/"
 REACT_APP_CHRIS_UI_AUTH_URL="${REACT_APP_CHRIS_UI_URL}auth-token/"
+
+# Set PFDCM_URL to the root url of the running pfdcm instance
+REACT_APP_PFDCM_URL="http://localhost:4005/"

--- a/src/api/pfdcm/index.ts
+++ b/src/api/pfdcm/index.ts
@@ -1,5 +1,12 @@
 import { parseRawDcmData } from "./pfdcm-utils";
 import mockData from "./mock_data";
+import axios, { AxiosRequestConfig } from "axios";
+
+declare const process: {
+  env: {
+    REACT_APP_PFDCM_URL: string;
+  }
+}
 
 type Modality = 'AR' | 'AU' | 'BDUS' | 'BI' | 'BMD' | 'CR' | 'CT' | 'DG' | 'DOC' | 'DX' | 'ECG' | 'EPS' | 'ES' | 'FID' | 'GM' | 'HC' | 'HD' | 'IO' | 'IOL' | 'IVOCT' | 'IVUS' | 'KER' | 'KO' | 'LEN' | 'LS' | 'MG' | 'MR' | 'NM' | 'OAM' | 'OCT' | 'OP' | 'OPM' | 'OPT' | 'OPV' | 'OT' | 'PLAN' | 'PR' | 'PT' | 'PX' | 'REG' | 'RESP' | 'RF' | 'RG' | 'RTDOSE' | 'RTIMAGE' | 'RTPLAN' | 'RTRECORD' | 'RTSTRUCT' | 'SEG' | 'SM' | 'SMR' | 'SR' | 'SRF' | 'TG' | 'US' | 'VA' | 'XA' | 'XC';
 type PatientSex = 'M' | 'F' | 'O';
@@ -60,9 +67,8 @@ export interface PACSPatient {
 }
 
 export interface PFDCMFilters {
-  date: string;
-  modality: Modality;
-  stationAETitle: string;
+  modality?: Modality;
+  station?: string;
 }
 
 class PFDCMClient {
@@ -98,21 +104,77 @@ class PFDCMClient {
     return Object.values(patientsDataMap);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static async queryByMrn(mrn: string, filters: PFDCMFilters): Promise<PACSPatient[]> {
-    const studies = parseRawDcmData(mockData);
+  // send request to the /pypx endpoint, used for query and retrieve
+  private static sendPypxRequest(pypxFind: any) {
+    const pfdcmUrl = process.env.REACT_APP_PFDCM_URL;
+    const config: AxiosRequestConfig = {
+      url: `${pfdcmUrl}api/v1/PACS/pypx/`,
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      data: {
+        PACSservice: {
+          "value": "orthanc"
+        },
+        listenerService: {
+          "value": "default"
+        },
+        pypx_find: {
+          ...pypxFind,
+          withFeedBack: false,
+          dblogbasepath: "/home/dicom/log",
+          json_response: true
+        }
+
+      }
+    }
+    return axios(config);
+  }
+
+  private static async queryPacs(query: any, filters: PFDCMFilters) {
+    // apply filters
+    if (filters.modality) {
+      query.ModalitiesInStudy = filters.modality;
+    }
+    if (filters.station) {
+      query.PerformedStationAETitle = filters.station;
+    }
+
+    const response = await this.sendPypxRequest({
+      ...query,
+      then: '',
+    })
+    const rawDcmData = response.data.pypx;
+    
+    const studies = parseRawDcmData(rawDcmData);
     return this.sortStudiesByPatient(studies);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static async queryByPatientName(name: string, filters: PFDCMFilters): Promise<PACSPatient[]> {
-    const studies = parseRawDcmData(mockData);
-    return this.sortStudiesByPatient(studies);
+  static queryByMrn(mrn: string, filters: PFDCMFilters = {}): Promise<PACSPatient[]> {
+    return this.queryPacs({ 
+      PatientId: mrn 
+    }, filters);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static async queryByStudy(study: string, filters: PFDCMFilters) {
-    return parseRawDcmData(mockData);
+  static queryByPatientName(name: string, filters: PFDCMFilters = {}): Promise<PACSPatient[]> {
+    return this.queryPacs({
+      PatientName: name,
+    }, filters);
+  }
+
+  static async queryByStudyDate(date: Date, filters: PFDCMFilters = {}) {
+    // date string format: yyyyMMddd (no spaces or dashes)
+    const dateString = date
+      .toISOString()
+      .split('T')[0]
+      .replace(/-/g, '');
+
+    return this.queryPacs({
+      StudyDate: dateString
+    }, filters);
+  }
   }
   
 }


### PR DESCRIPTION
This PR connects the PFDCM client to a running `pfdcm` instance. At the moment, only the query functions have been implemented. 